### PR TITLE
Melee deadzone timing support

### DIFF
--- a/WeaponSwingTimer.toc
+++ b/WeaponSwingTimer.toc
@@ -1,4 +1,4 @@
-## Interface: 11302
+## Interface: 20501
 ## Title-deDE: WeaponSwingTimer (Deutsch)
 ## Title-enUS: WeaponSwingTimer (English)
 ## Title-esES: WeaponSwingTimer (Español)

--- a/WeaponSwingTimer_Config.lua
+++ b/WeaponSwingTimer_Config.lua
@@ -27,7 +27,7 @@ addon_data.config.InitializeVisuals = function()
     InterfaceOptions_AddCategory(panel)
     
     -- Add the melee panel
-    panel.config_melee_panel = CreateFrame("Frame", nil, panel)
+    panel.config_melee_panel = CreateFrame("Frame", nil, panel, BackdropTemplateMixin and "BackdropTemplate")
     panel.config_melee_panel:SetSize(1, 1)
     panel.config_melee_panel.player_panel = addon_data.player.CreateConfigPanel(panel.config_melee_panel)
     panel.config_melee_panel.player_panel:SetPoint('TOPLEFT', 0, 0)
@@ -41,7 +41,7 @@ addon_data.config.InitializeVisuals = function()
     InterfaceOptions_AddCategory(panel.config_melee_panel)
     
     -- Add the hunter panel
-    panel.config_hunter_panel = CreateFrame("Frame", nil, panel)
+    panel.config_hunter_panel = CreateFrame("Frame", nil, panel, BackdropTemplateMixin and "BackdropTemplate")
     panel.config_hunter_panel:SetSize(1, 1)
     panel.config_hunter_panel.hunter_panel = addon_data.hunter.CreateConfigPanel(panel.config_hunter_panel)
     panel.config_hunter_panel.hunter_panel:SetPoint('TOPLEFT', 0, 0)
@@ -75,7 +75,11 @@ addon_data.config.CheckBoxFactory = function(g_name, parent, checkbtn_text, tool
 end
 
 addon_data.config.EditBoxFactory = function(g_name, parent, title, w, h, enter_func)
-    local edit_box_obj = CreateFrame("EditBox", addon_name .. g_name, parent)
+    local edit_box_obj = CreateFrame("EditBox", addon_name .. g_name, parent, BackdropTemplateMixin and "BackdropTemplate")
+    if edit_box_obj == nil then
+        return
+    end
+
     edit_box_obj.title_text = addon_data.config.TextFactory(edit_box_obj, title, 12)
     edit_box_obj.title_text:SetPoint("TOP", 0, 12)
     edit_box_obj:SetBackdrop({
@@ -150,7 +154,7 @@ addon_data.config.SliderFactory = function(g_name, parent, title, min_val, max_v
 end
 
 addon_data.config.color_picker_factory = function(g_name, parent, r, g, b, a, text, on_click_func)
-    local color_picker = CreateFrame('Button', addon_name .. g_name, parent)
+    local color_picker = CreateFrame('Button', addon_name .. g_name, parent, BackdropTemplateMixin and "BackdropTemplate")
     color_picker:SetSize(15, 15)
     color_picker.normal = color_picker:CreateTexture(nil, 'BACKGROUND')
     color_picker.normal:SetColorTexture(1, 1, 1, 1)
@@ -183,7 +187,7 @@ addon_data.config.IsLockedCheckBoxOnClick = function(self)
 end
 
 addon_data.config.CreateConfigPanel = function(parent_panel)
-    addon_data.config.config_frame = CreateFrame("Frame", addon_name .. "GlobalConfigPanel", parent_panel)
+    addon_data.config.config_frame = CreateFrame("Frame", addon_name .. "GlobalConfigPanel", parent_panel, BackdropTemplateMixin and "BackdropTemplate")
     local panel = addon_data.config.config_frame
     local settings = character_player_settings
     -- Title Text

--- a/WeaponSwingTimer_Hunter.lua
+++ b/WeaponSwingTimer_Hunter.lua
@@ -419,6 +419,10 @@ end
 addon_data.hunter.UpdateVisualsOnUpdate = function()
     local settings = character_hunter_settings
     local frame = addon_data.hunter.frame
+    if frame == nill then
+        return
+    end
+
     local range_speed = addon_data.hunter.range_speed
     local shot_timer = addon_data.hunter.shot_timer
     local auto_cast_time = addon_data.hunter.auto_cast_time
@@ -504,6 +508,10 @@ end
 addon_data.hunter.UpdateVisualsOnSettingsChange = function()
     local settings = character_hunter_settings
     local frame = addon_data.hunter.frame
+    if frame == nil then
+        return
+    end
+
 	if settings.enabled then
         frame:Show()
         frame:ClearAllPoints()
@@ -615,7 +623,7 @@ end
 addon_data.hunter.InitializeVisuals = function()
     local settings = character_hunter_settings
     -- Create the frame
-    addon_data.hunter.frame = CreateFrame("Frame", addon_name .. "HunterAutoshotFrame", UIParent)
+    addon_data.hunter.frame = CreateFrame("Frame", addon_name .. "HunterAutoshotFrame", UIParent, BackdropTemplateMixin and "BackdropTemplate")
     local frame = addon_data.hunter.frame
     frame:SetMovable(true)
     frame:EnableMouse(not settings.is_locked)
@@ -623,7 +631,7 @@ addon_data.hunter.InitializeVisuals = function()
     frame:SetScript("OnDragStart", addon_data.hunter.OnFrameDragStart)
     frame:SetScript("OnDragStop", addon_data.hunter.OnFrameDragStop)
     -- Create the backplane
-    frame.backplane = CreateFrame("Frame", addon_name .. "HunterBackdropFrame", frame)
+    frame.backplane = CreateFrame("Frame", addon_name .. "HunterBackdropFrame", frame, BackdropTemplateMixin and "BackdropTemplate")
     frame.backplane:SetPoint('TOPLEFT', -9, 9)
     frame.backplane:SetPoint('BOTTOMRIGHT', 9, -9)
     frame.backplane:SetFrameStrata('BACKGROUND')
@@ -860,7 +868,7 @@ addon_data.hunter.BackplaneAlphaOnValChange = function(self)
 end
 
 addon_data.hunter.CreateConfigPanel = function(parent_panel)
-    addon_data.hunter.config_frame = CreateFrame("Frame", addon_name .. "HunterConfigPanel", parent_panel)
+    addon_data.hunter.config_frame = CreateFrame("Frame", addon_name .. "HunterConfigPanel", parent_panel, BackdropTemplateMixin and "BackdropTemplate")
     local panel = addon_data.hunter.config_frame
     local settings = character_hunter_settings
     -- Title Text

--- a/WeaponSwingTimer_Target.lua
+++ b/WeaponSwingTimer_Target.lua
@@ -233,8 +233,13 @@ end
 --[[===================================== VISUALS RELATED ======================================]]--
 --[[============================================================================================]]--
 addon_data.target.UpdateVisualsOnUpdate = function()
-    local settings = character_target_settings
     local frame = addon_data.target.frame
+    if frame == nil then
+        return
+    end
+
+    local settings = character_target_settings
+
     if settings.enabled and UnitExists("target") then
         frame:Show()
         local main_speed = addon_data.target.main_weapon_speed
@@ -316,7 +321,12 @@ end
 
 addon_data.target.UpdateVisualsOnSettingsChange = function()
     local frame = addon_data.target.frame
+    if frame == nil then
+        return
+    end
+
     local settings = character_target_settings
+
     if settings.enabled then
         frame:Show()
         frame:ClearAllPoints()
@@ -431,7 +441,7 @@ addon_data.target.InitializeVisuals = function()
     frame:SetScript("OnDragStart", addon_data.target.OnFrameDragStart)
     frame:SetScript("OnDragStop", addon_data.target.OnFrameDragStop)
     -- Create the backplane
-    frame.backplane = CreateFrame("Frame", addon_name .. "TargetBackdropFrame", frame)
+    frame.backplane = CreateFrame("Frame", addon_name .. "TargetBackdropFrame", frame, BackdropTemplateMixin and "BackdropTemplate")
     frame.backplane:SetPoint('TOPLEFT', -9, 9)
     frame.backplane:SetPoint('BOTTOMRIGHT', 9, -9)
     frame.backplane:SetFrameStrata('BACKGROUND')
@@ -684,7 +694,7 @@ addon_data.target.BackplaneAlphaOnValChange = function(self)
 end
 
 addon_data.target.CreateConfigPanel = function(parent_panel)
-    addon_data.target.config_frame = CreateFrame("Frame", addon_name .. "TargetConfigPanel", parent_panel)
+    addon_data.target.config_frame = CreateFrame("Frame", addon_name .. "TargetConfigPanel", parent_panel, BackdropTemplateMixin and "BackdropTemplate")
     local panel = addon_data.target.config_frame
     local settings = character_target_settings
     -- Title Text


### PR DESCRIPTION
It was recently discovered that an on-hit weapon effect will not apply a debuff to the target if the weapon swing begins while the GCD is in effect.
I.e., the Nightfall debuff will not apply if a Paladin casts a spell, such as a new Seal, that triggers the GCD within 1.5 seconds of the end of the swing timer.

Additionally, certain Seal effects can take up to 1 second to apply after the swing begins.

To better indicate these behaviors, leading deadzones (for seal application effects) and trailing deadzones (for on-hit weapon effects) have been added, along with configuration values for the length of each deadzone. Defaults are 0 seconds for each to replicate existing behavior.