### PR TITLE
Fix Lua error after loading screen

### DIFF
--- a/WeaponSwingTimer_Player.lua
+++ b/WeaponSwingTimer_Player.lua
@@ -87,9 +87,11 @@ addon_data.player.OnUpdate = function(elapsed)
         end
         -- If the weapon speed changed for either hand then a buff occured and we need to modify the timers
         if addon_data.player.main_speed_changed or addon_data.player.off_speed_changed then
-            local main_multiplier = addon_data.player.main_weapon_speed / addon_data.player.prev_main_weapon_speed
-            addon_data.player.main_swing_timer = addon_data.player.main_swing_timer * main_multiplier
-            if addon_data.player.has_offhand then
+            if addon_data.player.main_swing_timer > 0 then
+                local main_multiplier = addon_data.player.main_weapon_speed / addon_data.player.prev_main_weapon_speed
+                addon_data.player.main_swing_timer = addon_data.player.main_swing_timer * main_multiplier
+            end
+            if addon_data.player.has_offhand and addon_data.player.off_swing_timer > 0 then
                 local off_multiplier = (addon_data.player.off_weapon_speed / addon_data.player.prev_off_weapon_speed)
                 addon_data.player.off_swing_timer = addon_data.player.off_swing_timer * off_multiplier
             end


### PR DESCRIPTION
Closes #25.

During a loading screen, `UnitAttackSpeed` will return `nil`s. When returning from the loading screen, this will result in `prev_off_weapon_speed` being `nil`, but `off_weapon_speed` being non-`nil`. A Lua error in `player.OnUpdate` results.

This PR circumvents the error by not calculating the swing timer multiplier unless necessary. (If either weapon's swing timer is zero, the multiplier is irrelevant.)