### PR TITLE
Fix off-hand swing timer on auto-attack start

### DIFF
--- a/WeaponSwingTimer_Core.lua
+++ b/WeaponSwingTimer_Core.lua
@@ -647,6 +647,7 @@ local function OnAddonLoaded(self)
     addon_data.core.core_frame:RegisterEvent("PLAYER_REGEN_ENABLED")
     addon_data.core.core_frame:RegisterEvent("PLAYER_REGEN_DISABLED")
     addon_data.core.core_frame:RegisterEvent("PLAYER_TARGET_CHANGED")
+    addon_data.core.core_frame:RegisterEvent("PLAYER_ENTER_COMBAT")
     addon_data.core.core_frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
     addon_data.core.core_frame:RegisterEvent("UNIT_INVENTORY_CHANGED")
     addon_data.core.core_frame:RegisterEvent("START_AUTOREPEAT_SPELL")
@@ -678,6 +679,8 @@ local function CoreFrame_OnEvent(self, event, ...)
         addon_data.core.in_combat = true
     elseif event == "PLAYER_TARGET_CHANGED" then
         addon_data.target.OnPlayerTargetChanged()
+    elseif event == "PLAYER_ENTER_COMBAT" then
+        addon_data.player.OnPlayerEnterCombat()
     elseif event == "COMBAT_LOG_EVENT_UNFILTERED" then
         local combat_info = {CombatLogGetCurrentEventInfo()}
         addon_data.player.OnCombatLogUnfiltered(combat_info)

--- a/WeaponSwingTimer_Player.lua
+++ b/WeaponSwingTimer_Player.lua
@@ -120,6 +120,12 @@ addon_data.player.OnInventoryChange = function()
     addon_data.player.off_weapon_id = new_off_guid
 end
 
+addon_data.player.OnPlayerEnterCombat = function()
+    if addon_data.player.has_offhand then
+        addon_data.player.off_swing_timer = max(addon_data.player.off_swing_timer, addon_data.player.off_weapon_speed * 0.5)
+    end
+end
+
 addon_data.player.OnCombatLogUnfiltered = function(combat_info)
     local _, event, _, source_guid, _, _, _, dest_guid, _, _, _, _, spell_name, _ = unpack(combat_info)
     if (source_guid == addon_data.player.guid) then


### PR DESCRIPTION
When a player begins auto-attacking, their off-hand weapon will be placed on a swing timer equal to 50% of its weapon speed.

This is frequently used by classes such as Enhancement Shamans to adjust their swing cadence, by intentionally re-starting auto attack to delay their off-hand swing.

This PR properly reflects this behavior in the swing timer displayed.